### PR TITLE
fix: atomic creation of VMs or fast fail

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -146,7 +146,7 @@ do
       ;;
     accelerator)
       accelerator=$OPTLARG
-      ;;      
+      ;;
     h|help)
       usage
       exit 0
@@ -269,6 +269,7 @@ function start_vm {
   gcloud compute instances bulk create \
     --name-pattern="${VM_ID}-#" \
     --count=${num_instances} \
+    --min-count=${num_instances} \
     --zone=${machine_zone} \
     ${disk_size_flag} \
     ${boot_disk_type_flag} \


### PR DESCRIPTION
From https://cloud.google.com/compute/docs/instances/multiple/create-in-bulk

> Compute Engine creates at least MIN_COUNT VMs up to a maximum of COUNT VMs. If MIN_COUNT VMs can't be created, the request fails and no VMs are created.
