### PR TITLE
fix: usage of $instance variable in shutdown scripts

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -204,7 +204,7 @@ function start_vm {
 	#!/bin/sh
 	sleep ${shutdown_timeout}
 	instance=\$(hostname)
-	gcloud compute instances delete \${instance} --zone=$machine_zone --quiet
+	gcloud compute instances delete \\\${instance} --zone=$machine_zone --quiet
 	EOF
 
 	cat <<-EOF > /etc/systemd/system/shutdown.service
@@ -223,7 +223,7 @@ function start_vm {
 	cat <<-EOF > /usr/bin/gce_runner_shutdown.sh
 	#!/bin/sh
 	instance=\$(hostname)
-	echo \"✅ Self deleting \${instance} in ${machine_zone} in ${shutdown_timeout} seconds ...\"
+	echo \"✅ Self deleting \\\${instance} in ${machine_zone} in ${shutdown_timeout} seconds ...\"
 	# We tear down the machine by starting the systemd service that was registered by the startup script
 	systemctl start shutdown.service
 	EOF


### PR DESCRIPTION
We need one `\` to escape the `$`, and two more to add a literal `\` which will escape the `$` when the `startup_script` is writing the two shutdown scripts. Without this change, the shutdown script ends up running `gcloud compute instances delete` with an empty instance argument.