### PR TITLE
fix: remove command chaining

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -258,7 +258,8 @@ function start_vm {
       cd /actions-runner
       curl -o actions-runner-linux-arm64-${runner_ver}.tar.gz -L https://github.com/actions/runner/releases/download/v${runner_ver}/actions-runner-linux-arm64-${runner_ver}.tar.gz
       tar xzf ./actions-runner-linux-arm64-${runner_ver}.tar.gz
-      ./bin/installdependencies.sh && \\
+      ./bin/installdependencies.sh
+
       $startup_script"
     else
       startup_script="#!/bin/bash
@@ -266,7 +267,8 @@ function start_vm {
       cd /actions-runner
       curl -o actions-runner-linux-x64-${runner_ver}.tar.gz -L https://github.com/actions/runner/releases/download/v${runner_ver}/actions-runner-linux-x64-${runner_ver}.tar.gz
       tar xzf ./actions-runner-linux-x64-${runner_ver}.tar.gz
-      ./bin/installdependencies.sh && \\
+      ./bin/installdependencies.sh
+
       $startup_script"
     fi
   fi


### PR DESCRIPTION
# Changes made
Remove command chaining, it's problematic in this case as errors will break initial commands in the `$startup_script`.

# Risks 
None