### PR TITLE
chore: add exit status check to gcloud command

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -293,13 +293,14 @@ function start_vm {
     ${maintenance_policy_flag} \
     --labels=gh_ready=0,vm_id=${VM_ID} \
     --metadata=startup-script="$startup_script"
-
-  echo $?
   echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off
   launched_instances=$(gcloud compute instances list --filter "labels.vm_id=${VM_ID}" --format='get(name)')
-  echo "Instances launched: $launched_instances"
+  if [ -z "$launched_instances" ]; then
+    echo "Failed to launch VMs"
+    exit 1
+  fi
 
   for instance in $launched_instances; do
     while (( i++ < 60 )); do

--- a/action.sh
+++ b/action.sh
@@ -293,7 +293,12 @@ function start_vm {
     ${maintenance_policy_flag} \
     --labels=gh_ready=0,vm_id=${VM_ID} \
     --metadata=startup-script="$startup_script"
- 
+
+  if [ $? -ne 0 ]; then
+    echo "Error: Failed to create VM(s)"
+    exit 1
+  fi
+
   echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off

--- a/action.sh
+++ b/action.sh
@@ -293,7 +293,7 @@ function start_vm {
     ${maintenance_policy_flag} \
     --labels=gh_ready=0,vm_id=${VM_ID} \
     --metadata=startup-script="$startup_script"
-  
+ 
   echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off

--- a/action.sh
+++ b/action.sh
@@ -293,6 +293,7 @@ function start_vm {
     ${maintenance_policy_flag} \
     --labels=gh_ready=0,vm_id=${VM_ID} \
     --metadata=startup-script="$startup_script"
+  
   echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off

--- a/action.sh
+++ b/action.sh
@@ -294,15 +294,15 @@ function start_vm {
     --labels=gh_ready=0,vm_id=${VM_ID} \
     --metadata=startup-script="$startup_script"
 
-  if [ $? -ne 0 ]; then
-    echo "Error: Failed to create VM(s)"
-    exit 1
-  fi
-
   echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off
   launched_instances=$(gcloud compute instances list --filter "labels.vm_id=${VM_ID}" --format='get(name)')
+  if [ ${#launched_instances[@]} -eq 0 ]; then
+    echo "Error: Failed to create VM(s)"
+    exit 1
+  fi
+
   for instance in $launched_instances; do
     while (( i++ < 60 )); do
       GH_READY=$(gcloud compute instances describe ${instance} --zone=${machine_zone} --format='json(labels)' | jq -r .labels.gh_ready)

--- a/action.sh
+++ b/action.sh
@@ -294,14 +294,12 @@ function start_vm {
     --labels=gh_ready=0,vm_id=${VM_ID} \
     --metadata=startup-script="$startup_script"
 
+  echo $?
   echo "label=${VM_ID}" >> $GITHUB_OUTPUT
 
   safety_off
   launched_instances=$(gcloud compute instances list --filter "labels.vm_id=${VM_ID}" --format='get(name)')
-  if [ ${#launched_instances[@]} -eq 0 ]; then
-    echo "Error: Failed to create VM(s)"
-    exit 1
-  fi
+  echo "Instances launched: $launched_instances"
 
   for instance in $launched_instances; do
     while (( i++ < 60 )); do


### PR DESCRIPTION
Right now the create-runner action will occasionally fail to create the runner, but will not report the job as failed. On [a recent run where we observed this](https://github.com/teamsnap/organization-v2-api/actions/runs/12831205981/job/35781076413?pr=120), we saw:

`ERROR: <ErrorsValueListEntry
 code: 'VM_MIN_COUNT_NOT_REACHED'
 errorDetails: []
 message: 'Requested minimum count of 1 VMs could not be created.'>`

I couldn't find much about this error, but I did find one thread in the googleapis repo discussing this exact error with regards to `BulkInsertInstances`: https://github.com/googleapis/google-cloud-go/issues/7876

This made me think that the error is being unhandled following the `gcloud compute instances bulk create` command, so my proposed solution is adding a check to the `gcloud` exit status, and explicitly failing the job if it did not succeed.