### PR TITLE
fix: ensure shutdown uses the service account configured for instance

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -203,6 +203,8 @@ function start_vm {
 	cat <<-EOF > /etc/systemd/system/shutdown.sh
 	#!/bin/sh
 	sleep ${shutdown_timeout}
+	# ensure the active gcloud account in the shutdown script is the same one configured on instance creation
+	gcloud config set account \$(gcloud auth list --filter=status:ACTIVE --format=\"value(account)\")
 	instance=\$(hostname)
 	gcloud compute instances delete \\\${instance} --zone=$machine_zone --quiet
 	EOF


### PR DESCRIPTION
Github actions that run gcloud auth may override the active service account specified when the runner instance(s) are created, which can cause permissions issues during runner shutdown (e.g. the overriding account may not have permissions to terminate the instance).

This PR updates the shutdown script to explicitly set the active gcloud account to the one that's active when the startup script runs, which should be the service account configured for the instance (or the default service account if none is provided in the instance creation command).

### Testing
I confirmed that this change works as intended by pointing to this branch from a github workflow that uses this runner; the runner instance was terminated upon completion of the workflow.